### PR TITLE
chore(admin): 첫 배포 준비 — TS 빌드 통과 + /opt/admin 경로 정리 + SSH 셋업 문서

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [main]
     paths:
-      - 'apps/admin/**'
-      - 'packages/api/**'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/deploy-admin.yml'
+      - "apps/admin/**"
+      - "packages/api/**"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/deploy-admin.yml"
   workflow_dispatch:
 
 concurrency:
@@ -26,8 +26,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'pnpm'
+          node-version: "20"
+          cache: "pnpm"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -35,8 +35,8 @@ jobs:
       - name: Build admin
         run: pnpm --filter @ddd/admin... build
         env:
-          VITE_API_URL: ''
-          VITE_MSW_ENABLED: 'false'
+          VITE_API_URL: ""
+          VITE_MSW_ENABLED: "false"
 
       - name: Pack dist
         run: tar -czf admin-dist.tar.gz -C apps/admin/dist .
@@ -48,7 +48,7 @@ jobs:
           username: ${{ secrets.GCP_VM_USER }}
           key: ${{ secrets.GCP_VM_SSH_KEY }}
           source: admin-dist.tar.gz
-          target: /opt/ddd-be/frontend/
+          target: /opt/admin/frontend/
 
       - name: Atomic swap
         uses: appleboy/ssh-action@v1.0.3
@@ -59,7 +59,7 @@ jobs:
           envs: GITHUB_SHA
           script: |
             set -euo pipefail
-            cd /opt/ddd-be/frontend
+            cd /opt/admin/frontend
             REL="releases/$(date +%Y%m%d-%H%M%S)-${GITHUB_SHA::7}"
             mkdir -p "$REL"
             tar -xzf admin-dist.tar.gz -C "$REL"

--- a/apps/admin/src/entities/application/model/useApplicationsBoard.ts
+++ b/apps/admin/src/entities/application/model/useApplicationsBoard.ts
@@ -75,7 +75,7 @@ export const useApplicationsBoard = ({
       params: {
         ...(effectiveCohortId !== undefined && { cohortId: effectiveCohortId }),
         ...(cohortPartId !== undefined && { cohortPartId }),
-        ...(status !== undefined && { status: status as string }),
+        ...(status !== undefined && { status }),
       },
     }),
   )

--- a/apps/admin/src/entities/cohort/model/completion.ts
+++ b/apps/admin/src/entities/cohort/model/completion.ts
@@ -46,9 +46,9 @@ export const isCurriculumComplete = (curriculum: unknown): boolean => {
 const isPartsComplete = (parts: unknown): boolean => {
   if (!Array.isArray(parts) || parts.length === 0) return false
   return PARTS.every((partName) => {
-    const part = (parts as CohortPartConfig[]).find((p) => p.name === partName)
+    const part = (parts as CohortPartConfig[]).find((p) => p.partName === partName)
     if (!part) return false
-    const questions = (part.formSchema as Record<string, unknown>)?.questions
+    const questions = (part.applicationSchema as Record<string, unknown>)?.questions
     if (!Array.isArray(questions)) return false
     return questions.some(
       (q) =>

--- a/apps/admin/src/entities/cohort/model/serialize.ts
+++ b/apps/admin/src/entities/cohort/model/serialize.ts
@@ -84,11 +84,11 @@ export const serializeFormToUpdatePayload = (
 export const serializeFormToPartsPayload = (
   form: SemesterRegisterForm
 ): PutUpdateCohortPartsRequest => ({
-  parts: PARTS.map((name) => ({
-    name,
-    isOpen: form.parts[name].isOpen,
-    formSchema: {
-      questions: form.parts[name].questions.map(({ key, label, required }) => ({
+  parts: PARTS.map((partName) => ({
+    partName,
+    isOpen: form.parts[partName].isOpen,
+    applicationSchema: {
+      questions: form.parts[partName].questions.map(({ key, label, required }) => ({
         key: key.trim() || slugify(label),
         label,
         required,
@@ -166,12 +166,12 @@ const extractParts = (
   if (!Array.isArray(raw) || raw.length === 0) return null
   const result = {} as SemesterRegisterForm["parts"]
   for (const part of PARTS) {
-    const found = (raw as CohortPartConfig[]).find((p) => p.name === part)
+    const found = (raw as CohortPartConfig[]).find((p) => p.partName === part)
     if (!found) {
       result[part] = defaultPartState()
       continue
     }
-    const rawQuestions = (found.formSchema as Record<string, unknown>)
+    const rawQuestions = (found.applicationSchema as Record<string, unknown>)
       ?.questions
     const questions: CohortPartQuestion[] = Array.isArray(rawQuestions)
       ? rawQuestions

--- a/apps/admin/src/entities/cohort/model/useCreateOrUpdateCohortFlow.ts
+++ b/apps/admin/src/entities/cohort/model/useCreateOrUpdateCohortFlow.ts
@@ -11,11 +11,10 @@ import {
 
 export class PartsSaveAfterCreateError extends Error {
   readonly name = "PartsSaveAfterCreateError"
-  constructor(
-    public readonly newCohortId: number,
-    public readonly cause: unknown
-  ) {
-    super("Cohort created but parts save failed")
+  readonly newCohortId: number
+  constructor(newCohortId: number, cause: unknown) {
+    super("Cohort created but parts save failed", { cause })
+    this.newCohortId = newCohortId
   }
 }
 

--- a/apps/admin/src/pages/applications/components/ApplicationDetailDrawer/components/InterviewSlotsRequiredModal.tsx
+++ b/apps/admin/src/pages/applications/components/ApplicationDetailDrawer/components/InterviewSlotsRequiredModal.tsx
@@ -30,7 +30,7 @@ export const InterviewSlotsRequiredModal = ({
         <Modal.Container>
           <Modal.Dialog>
             <Modal.Header>
-              <Modal.Icon status="warning" />
+              <Modal.Icon />
               <Modal.Heading>면접 슬롯이 준비되지 않았습니다</Modal.Heading>
             </Modal.Header>
             <Modal.Body>

--- a/apps/admin/src/pages/applications/components/ApplicationDetailDrawer/components/StatusChangeModal.tsx
+++ b/apps/admin/src/pages/applications/components/ApplicationDetailDrawer/components/StatusChangeModal.tsx
@@ -41,7 +41,7 @@ export const StatusChangeModal = ({
     try {
       await mutateAsync({
         params: { id: applicationId },
-        payload: { status: nextStatus as string },
+        payload: { status: nextStatus },
       })
       await queryClient.invalidateQueries({ queryKey: applicationKeys.adminLists() })
       await queryClient.invalidateQueries({

--- a/apps/admin/src/pages/applications/components/ApplicationDetailDrawer/index.tsx
+++ b/apps/admin/src/pages/applications/components/ApplicationDetailDrawer/index.tsx
@@ -119,7 +119,7 @@ export const ApplicationDetailDrawer = ({
                         label="동의 일자"
                         value={formatDate(application.privacyAgreedAt)}
                       />
-                      <InfoRow label="현재 상태" value={application.status} />
+                      <InfoRow label="현재 상태" value={application.status ?? "-"} />
                     </dl>
                   </Section>
 

--- a/apps/admin/src/pages/interview-slots/components/InterviewSlotRegisterDrawer.tsx
+++ b/apps/admin/src/pages/interview-slots/components/InterviewSlotRegisterDrawer.tsx
@@ -109,7 +109,7 @@ export function InterviewSlotRegisterDrawer({
   }
 
   const onPartPick = (part: CohortPartConfigDto) => {
-    setValue("cohortPartId", part.id, { shouldValidate: false })
+    setValue("cohortPartId", part.id ?? 0, { shouldValidate: false })
     setValue("cohortPartName", part.partName, { shouldValidate: false })
   }
 

--- a/apps/admin/src/pages/interview-slots/components/InterviewSlotsToolbar.tsx
+++ b/apps/admin/src/pages/interview-slots/components/InterviewSlotsToolbar.tsx
@@ -84,7 +84,7 @@ export const InterviewSlotsToolbar = ({
                   key={part.id}
                   id={String(part.id)}
                   textValue={part.partName}
-                  onClick={() => onPartFilterChange(part.id)}
+                  onClick={() => part.id !== undefined && onPartFilterChange(part.id)}
                 >
                   {part.partName}
                 </ListBox.Item>

--- a/docs/admin-deploy.md
+++ b/docs/admin-deploy.md
@@ -41,7 +41,7 @@ OAuth 콜백은 전부 `/api/v1/*` 아래라 BE 가 처리. **프론트는 콜�
 | 항목 | 결정 |
 | --- | --- |
 | 배포 트리거 | **FE 레포 CI 단독** — BE 배포와 독립 |
-| 정적 파일 위치 | VM 호스트 `/opt/ddd-be/frontend/current/` (BE compose 가 `/srv/frontend` 로 마운트) |
+| 정적 파일 위치 | VM 호스트 `/opt/admin/frontend/current/` (BE compose 가 `/srv/frontend` 로 마운트) |
 | 배포 원자성 | **Symlink 스왑** — `releases/<sha>/` 에 풀고 `current` 심볼릭 링크 교체 |
 | SSH 사용자 | BE 배포용 user 재사용 (`GCP_VM_USER` / `GCP_VM_SSH_KEY`) |
 | 빌드 환경변수 | `VITE_API_URL=""` (코드가 `window.location.origin` 자동 결합) |
@@ -57,7 +57,7 @@ BE 가 선행해야 FE 첫 배포가 정상 동작한다. 핵심 작업:
 
 - Caddyfile 에 `/api/*` 분기 + SPA fallback 추가
 - `docker-compose.yml` 의 caddy 서비스에 `./frontend/current:/srv/frontend:ro` 볼륨 마운트
-- `deploy.yml` 또는 부트스트랩 스크립트에 `mkdir -p /opt/ddd-be/frontend/current` + placeholder `index.html`
+- `deploy.yml` 또는 부트스트랩 스크립트에 `mkdir -p /opt/admin/frontend/current` + placeholder `index.html`
 - 환경변수 `CLIENT_REDIRECT_URL=https://admin.dddstudy.kr/applications` 갱신
 - (선택) `GET /api/v1/users/me` 엔드포인트 추가 — 옵션 A 가드 도입 시 필요
 - 외부 콘솔(Google/Discord)의 OAuth redirect URI 가 이미 `admin.dddstudy.kr` 라면 변경 없음
@@ -208,10 +208,10 @@ ssh -i ~/.ssh/ddd_fe_deploy -o IdentitiesOnly=yes dddstudy1@<GCP_VM_HOST>
 
 ```bash
 # 배포 디렉터리 존재 + 쓰기 권한
-test -w /opt/ddd-be/frontend && echo "OK: writable" || echo "FAIL: not writable"
+test -w /opt/admin/frontend && echo "OK: writable" || echo "FAIL: not writable"
 
 # placeholder index.html
-ls -la /opt/ddd-be/frontend/current/ 2>/dev/null
+ls -la /opt/admin/frontend/current/ 2>/dev/null
 
 # Caddy 외부 응답
 curl -fsI https://admin.dddstudy.kr/ | head -n 1
@@ -267,7 +267,7 @@ paste 후 secret 페이지에 3 개가 "Updated now" 표시되면 등록 완료.
 
 VM 에서:
 ```bash
-cd /opt/ddd-be/frontend
+cd /opt/admin/frontend
 ls releases/                    # 보관된 릴리스 확인
 ln -sfn releases/<previous-sha> current.new && mv -Tf current.new current
 ```
@@ -313,7 +313,7 @@ A. 현재 워크플로는 main 푸시만 트리거. preview 가 필요해지면 
 ### BE 측 (담당자 회신 필요)
 - [ ] Caddyfile 에 `/api/*` 분기 + `try_files` SPA fallback 추가
 - [ ] `docker-compose.yml` 의 caddy 서비스에 frontend 볼륨 마운트
-- [ ] `/opt/ddd-be/frontend/current/` 부트스트랩 + placeholder `index.html`
+- [ ] `/opt/admin/frontend/current/` 부트스트랩 + placeholder `index.html`
 - [ ] `CLIENT_REDIRECT_URL=https://admin.dddstudy.kr/applications` 갱신
 - [ ] prod 쿠키 플래그 (`httpOnly`, `secure`, `sameSite=lax`) 점검
 
@@ -330,7 +330,7 @@ A. 현재 워크플로는 main 푸시만 트리거. preview 가 필요해지면 
 - [ ] FE 전용 SSH 키 쌍 생성 — `ssh-keygen -t ed25519 -f ~/.ssh/ddd_fe_deploy -C "ddd-fe-deploy@github-actions" -N ""`
 - [ ] public key (`~/.ssh/ddd_fe_deploy.pub`) 를 VM 의 `<GCP_VM_USER>` 계정 `authorized_keys` 에 등록 (§6.2 경로 A/B/C 중 택일)
 - [ ] 로컬에서 `ssh -i ~/.ssh/ddd_fe_deploy -o IdentitiesOnly=yes <GCP_VM_USER>@<GCP_VM_HOST>` 인증 통과 확인
-- [ ] VM 안에서 BE 부트스트랩 상태 확인 (`/opt/ddd-be/frontend/` 쓰기 권한 + Caddy 응답)
+- [ ] VM 안에서 BE 부트스트랩 상태 확인 (`/opt/admin/frontend/` 쓰기 권한 + Caddy 응답)
 - [ ] GitHub Secrets 3 개 등록 (`GCP_VM_HOST`, `GCP_VM_USER`, `GCP_VM_SSH_KEY`)
 - [ ] Actions 탭 "Run workflow" 로 첫 배포 수동 실행 → 단계별 통과 확인
 

--- a/docs/admin-deploy.md
+++ b/docs/admin-deploy.md
@@ -112,13 +112,123 @@ main 브랜치 push 시 트리거. `workflow_dispatch` 로 수동 실행도 가�
 
 ## 6. GitHub Secrets
 
-프론트 레포 Settings → Secrets and variables → Actions:
+프론트 레포 Settings → Secrets and variables → Actions 에 아래 3 개 등록:
 
-- `GCP_VM_HOST` — VM IP/호스트
-- `GCP_VM_USER` — BE 와 동일 user
-- `GCP_VM_SSH_KEY` — BE 와 동일 private key
+| Secret | 값 | 출처 |
+|---|---|---|
+| `GCP_VM_HOST` | VM IPv4 또는 도메인 (예: `35.216.102.35`) | BE 담당자로부터 전달 |
+| `GCP_VM_USER` | SSH 로그인 user (예: `dddstudy1`) | BE 담당자로부터 전달 — BE 배포 user 와 동일 |
+| `GCP_VM_SSH_KEY` | FE 전용 SSH **private key 전체** (`-----BEGIN OPENSSH PRIVATE KEY-----` ~ `-----END OPENSSH PRIVATE KEY-----` 줄 포함, 중간 줄바꿈 보존) | FE 측에서 `ssh-keygen` 으로 새로 생성. public 짝은 VM `authorized_keys` 에 등록 |
 
-BE 레포의 동일 값을 그대로 복사. 추후 보안 강화가 필요하면 frontend-deploy 전용 user 로 분리하는 방안 재검토.
+> **시나리오**: user 는 BE 와 공유, 키는 FE 전용으로 분리 (시나리오 B). BE 의 private key 를 그대로 복사(시나리오 A)할 수도 있으나, 키 회전·회수 시 영향 격리를 위해 FE 전용 키를 권장.
+
+### 6.1 SSH 키 쌍 생성 — FE 로컬
+
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/ddd_fe_deploy -C "ddd-fe-deploy@github-actions" -N ""
+```
+
+| 플래그 | 의미 |
+|---|---|
+| `-t ed25519` | 알고리즘 (RSA 보다 짧고 빠름, 동일 보안) |
+| `-f ~/.ssh/ddd_fe_deploy` | 출력 파일 경로. 두 파일 생성: `ddd_fe_deploy` (private) + `ddd_fe_deploy.pub` (public) |
+| `-C "ddd-fe-deploy@github-actions"` | comment(라벨). `authorized_keys` 끝에 한 줄로 남아 키 식별용. 동작에는 영향 없음 |
+| `-N ""` | passphrase 비움. **필수** — `appleboy/ssh-action` 이 passphrase 입력 불가 |
+
+생성 직후 화면에 뜨는 `SHA256:...` fingerprint 와 randomart 는 식별용 표시일 뿐이라 별도 저장 불필요. 진짜 키는 위 두 파일에 들어있음.
+
+### 6.2 public key (`.pub`) 를 VM 에 등록
+
+본인이 VM SSH 접근 권한이 없는 상태에서 시작하는 게 보통. 본인 권한에 따라 경로 택일.
+
+**경로 A — 팀 Google 계정으로 GCP 콘솔 브라우저 SSH (권장)**
+
+팀 구글 계정에 GCP 프로젝트 IAM 권한 (`compute.instanceAdmin.v1` 또는 sudo 가능한 user 매핑) 이 있으면 본인 손으로 끝낼 수 있음.
+
+1. 시크릿 창에서 `console.cloud.google.com` 팀 계정 로그인
+2. Compute Engine → VM 인스턴스 → 해당 VM 행의 **"SSH"** 버튼 → 브라우저 터미널
+3. 터미널에서:
+
+```bash
+sudo -u dddstudy1 mkdir -p /home/dddstudy1/.ssh
+sudo chmod 700 /home/dddstudy1/.ssh
+
+echo '<여기에 ddd_fe_deploy.pub 한 줄 paste>' \
+  | sudo tee -a /home/dddstudy1/.ssh/authorized_keys
+
+sudo chown dddstudy1:dddstudy1 /home/dddstudy1/.ssh/authorized_keys
+sudo chmod 600 /home/dddstudy1/.ssh/authorized_keys
+
+# 확인
+sudo tail -n 1 /home/dddstudy1/.ssh/authorized_keys
+```
+
+권한 모드(`700` / `600`)는 SSH 서버가 엄격하게 검사하므로 빠뜨리면 인증 통과 안 됨.
+
+**경로 B — BE 담당자에게 의뢰**
+
+콘솔 권한이 없거나 OS Login 환경이라 user 매핑이 복잡한 경우.
+
+> 어드민 FE 배포 파이프라인용 SSH key 등록 부탁드립니다.
+> VM: `<GCP_VM_HOST>` / 대상 user: `dddstudy1`
+> 추가할 public key (한 줄):
+> ```
+> <cat ~/.ssh/ddd_fe_deploy.pub 결과>
+> ```
+> `~dddstudy1/.ssh/authorized_keys` 끝에 append 부탁드립니다.
+
+`.pub` 키는 공개 정보라 슬랙·메일에 평문으로 그대로 전달해도 보안 문제 없음. **절대 노출 금지인 건 `.pub` 안 붙은 private 쪽뿐**.
+
+**경로 C — GCP 콘솔 메타데이터 UI (함정 주의)**
+
+VM 상세 → "수정" → "SSH 키" 섹션 → "항목 추가" 도 가능. 단 GCP 가 key 끝의 comment 를 Linux user 이름으로 자동 매핑하므로, paste 전에 comment 를 `ddd-fe-deploy@github-actions` → `dddstudy1` 로 바꿔야 받은 user 와 일치. OS Login 이 켜져 있으면 이 메타데이터가 무시되므로 경로 A 또는 B 로 가야 함.
+
+### 6.3 로컬에서 SSH 인증 검증
+
+secret 등록 전에 반드시 확인. GitHub Actions 가 쓰는 라이브러리와 동일한 SSH 메커니즘이라 로컬 통과 = 파이프라인 통과 (거의 확정).
+
+```bash
+ssh -i ~/.ssh/ddd_fe_deploy -o IdentitiesOnly=yes dddstudy1@<GCP_VM_HOST>
+```
+
+- `-i` : 사용할 private key 지정
+- `-o IdentitiesOnly=yes` : agent/기본키 무시하고 `-i` 지정 키만 시도 (정확한 검증)
+
+비밀번호 안 묻고 셸 떨어지면 성공. 첫 접속이면 known_hosts confirm 한 번(`yes`).
+
+**실패 시 진단**
+
+| 증상 | 의심 |
+|---|---|
+| `Permission denied (publickey)` | `.pub` 이 `dddstudy1` 의 `authorized_keys` 에 없거나 권한 모드(700/600) 미충족 |
+| `Connection timed out` | host 오타 또는 22 포트 방화벽 차단 |
+| `Offering public key` 로그가 안 나옴 (`-vvv` 옵션으로 확인) | private key 파일 권한 문제. `chmod 600 ~/.ssh/ddd_fe_deploy` |
+
+**셸에 들어간 김에 BE 측 부트스트랩 확인**:
+
+```bash
+# 배포 디렉터리 존재 + 쓰기 권한
+test -w /opt/ddd-be/frontend && echo "OK: writable" || echo "FAIL: not writable"
+
+# placeholder index.html
+ls -la /opt/ddd-be/frontend/current/ 2>/dev/null
+
+# Caddy 외부 응답
+curl -fsI https://admin.dddstudy.kr/ | head -n 1
+```
+
+위 3 개 중 하나라도 실패면 §3 BE 측 작업이 미완 — BE 에 의뢰해 채워야 첫 배포가 끝까지 통과함.
+
+### 6.4 GitHub Secrets 에 paste
+
+GitHub 레포 Settings → Secrets and variables → Actions → **"New repository secret"** 으로 3 개 차례 등록.
+
+```bash
+# macOS: private key 를 클립보드로 (BEGIN/END 줄·줄바꿈 보존)
+pbcopy < ~/.ssh/ddd_fe_deploy
+```
+
+paste 후 secret 페이지에 3 개가 "Updated now" 표시되면 등록 완료. 값은 다시 못 보지만 잘못 paste 됐으면 "Update" 로 재입력.
 
 ---
 
@@ -126,11 +236,13 @@ BE 레포의 동일 값을 그대로 복사. 추후 보안 강화가 필요하�
 
 1. **BE 가 먼저** — Caddyfile / compose / 부트스트랩 스크립트 변경 + placeholder 세팅 배포
    - 이 단계까지는 Caddy 가 placeholder `index.html` 을 서빙
-2. **GitHub Secrets 등록** (§6) — 머지 전 필수
-3. **FE 가 다음** — main 머지 또는 Actions 탭 `workflow_dispatch` 실행
+2. **FE SSH 키 셋업** (§6) — 키 쌍 생성 → VM `authorized_keys` 등록 → 로컬 `ssh -i` 검증 → GitHub Secrets 3 개 paste. **로컬 SSH 검증이 통과해야 다음 단계로 진행**
+3. **첫 배포는 수동 실행 권장** — Actions 탭 → "Deploy admin to GCP VM" → **Run workflow** (`workflow_dispatch`). 자동 트리거(main 푸시) 보다 먼저 한 번 수동으로 돌려 단계별 로그를 확인
    - `current` 가 실제 빌드로 교체됨
+   - Atomic swap 또는 Health check 에서 막히면 §3 BE 측 작업이 미완인 신호
 4. **(선택) OAuth 콘솔 점검** — 이미 `admin.dddstudy.kr` 면 변경 없음
 5. **검증** — §8 시나리오 통과 확인
+6. **자동 트리거 확정** — 이후 `main` 푸시 시 자동 배포가 도는지 한 번 더 확인 (예: 의도된 작은 변경을 머지하여 워크플로 자동 실행 여부 점검)
 
 ---
 
@@ -214,7 +326,13 @@ A. 현재 워크플로는 main 푸시만 트리거. preview 가 필요해지면 
 - [x] `.github/workflows/deploy-admin.yml` 추가
 - [x] `apps/admin/index.html` `<meta robots>` (선재 존재)
 - [x] `apps/admin/public/robots.txt` `Disallow: /` (선재 존재)
-- [ ] GitHub Secrets 등록 (`GCP_VM_HOST`, `GCP_VM_USER`, `GCP_VM_SSH_KEY`)
+- [ ] BE 담당자로부터 `GCP_VM_HOST`, `GCP_VM_USER` 값 전달받기
+- [ ] FE 전용 SSH 키 쌍 생성 — `ssh-keygen -t ed25519 -f ~/.ssh/ddd_fe_deploy -C "ddd-fe-deploy@github-actions" -N ""`
+- [ ] public key (`~/.ssh/ddd_fe_deploy.pub`) 를 VM 의 `<GCP_VM_USER>` 계정 `authorized_keys` 에 등록 (§6.2 경로 A/B/C 중 택일)
+- [ ] 로컬에서 `ssh -i ~/.ssh/ddd_fe_deploy -o IdentitiesOnly=yes <GCP_VM_USER>@<GCP_VM_HOST>` 인증 통과 확인
+- [ ] VM 안에서 BE 부트스트랩 상태 확인 (`/opt/ddd-be/frontend/` 쓰기 권한 + Caddy 응답)
+- [ ] GitHub Secrets 3 개 등록 (`GCP_VM_HOST`, `GCP_VM_USER`, `GCP_VM_SSH_KEY`)
+- [ ] Actions 탭 "Run workflow" 로 첫 배포 수동 실행 → 단계별 통과 확인
 
 ### 배포 후 (브라우저)
 - [ ] §8 검증 시나리오 1~8 전 통과
@@ -238,4 +356,4 @@ A. 현재 워크플로는 main 푸시만 트리거. preview 가 필요해지면 
 
 ---
 
-**마지막 수정**: 2026-05-11
+**마지막 수정**: 2026-05-13

--- a/docs/admin-implementation-status.md
+++ b/docs/admin-implementation-status.md
@@ -1,6 +1,6 @@
 # 어드민 기능 구현 현황
 
-> 기준일: 2026-05-08
+> 기준일: 2026-05-12
 > 기준 문서: 어드민 기능 명세서 v1 (3.1 ~ 3.5)
 > 백엔드: 별도 레포 (스키마·엔드포인트는 백엔드 구현 상태를 우선으로 따른다)
 > 프론트엔드: `apps/admin` (이 레포)
@@ -105,7 +105,7 @@ FE: `entities/application/model/constants.ts` `STATUS_BRANCH` 로 합격/불합�
 
 | 명세 항목 | 처리 주체 | 백엔드 | 프론트엔드 | 비고 |
 |-----------|-----------|--------|-----------|------|
-| 지원자 목록 (기수·파트·이름·상태·면접일자) | 양쪽 | ✅ | ⚠️ | BE: `GET /admin/applications`. FE: `ApplicationsPage` + `ApplicationTable`. **면접일자 컬럼 미노출** (slot UI 미구현 영향) |
+| 지원자 목록 (기수·파트·이름·상태·면접일자) | 양쪽 | ✅ | ✅ | BE: `GET /admin/applications`. FE: `ApplicationsPage` + `ApplicationTable`. 면접일자 컬럼은 `useApplicationsBoard` 가 `interviewQueries.getInterviewSlots` 응답의 `reservations[].applicationFormId → slot.startAt` 로 Map 을 만들어 테이블에 전달 (commit 197834b) |
 | 파트별 / 기수별 / 상태별 필터 | 프론트엔드 | – | ✅ | FE: `ApplicationFilters.tsx` (검색·기수·파트·상태) |
 | 상태별 카운트 카드 | 프론트엔드 | – | ✅ | FE: `useApplicationsBoard` + `Sections.tsx` `CardSection` |
 | 행 클릭 → 상세 진입 | 프론트엔드 | – | ✅ | FE: `Drawer` 형태로 진입 (페이지 전환 X) |
@@ -201,7 +201,7 @@ FE: `entities/application/model/constants.ts` `STATUS_BRANCH` 로 합격/불합�
 | 4 | 지원 | 서류합격 시 슬롯 없을 때 팝업 안내 | 양쪽 | ⚠️ | ✅ | FE: `InterviewSlotsRequiredModal` (HeroUI Modal) 노출 → `/interview-slots?cohortId&cohortPartId` 로 navigate. BE 측은 여전히 trigger 만 정상 |
 | 5 | 지원 | 최종합격 이메일 내 Discord OAuth 버튼 | 백엔드 | ⚠️ | – | BE: `EmailEventHandler` 최종합격 템플릿 Discord OAuth URL 포함 확인 |
 | 6 | 지원 | Google Meet 링크 생성 | 백엔드 | ⚠️ | – | BE: `GoogleCalendarClient` 이벤트 `conferenceData` 포함 확인 |
-| 7 | 지원 | 면접일자 컬럼 / 슬롯 중복 안내 | 양쪽 | ✅ | ❌ | FE: 지원자 테이블에 면접 슬롯 일정 컬럼 추가, 슬롯 관리 UI 도입 후 연계 |
+| 7 | 지원 | 슬롯 중복 시 "이미 선택된 시간" 안내 | 양쪽 | ✅ | – | BE: `400 INTERVIEW_SLOT_ALREADY_RESERVED` 반환. FE: 지원자용 일정 선택 페이지는 `apps/web` 영역으로 admin 범위 밖. (면접일자 컬럼은 197834b 에서 완료) |
 | 8 | 지원 | 개인정보 동의 일자 표시 | 양쪽 | ⚠️ | ✅ | FE: `ApplicationDetailDrawer` 에 동의 일자 `InfoRow` 추가 완료. BE: 상세 응답 `privacyAgreedAt` 포함 여부 확인 남음 |
 | 9 | 프로젝트 | 참여자 후기(review) 필드 | 양쪽 | ❌ | ⚠️ | BE: `ProjectMember` 에 `review` 필드 추가 + 마이그레이션 + DTO 노출. FE: `buildProjectFormDefaults` 와 `useCreateOrUpdateProjectFlow` payload 에 `review` 반영 |
 | 10 | 프로젝트 | PDF 업로드 (Phase 2) | 양쪽 | ❌ | ❌ | Phase 2 — 미착수 |

--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
       "esbuild",
       "sharp",
       "unrs-resolver"
-    ]
+    ],
+    "overrides": {
+      "@internationalized/date": "3.12.1"
+    }
   }
 }

--- a/packages/api/src/cohort/api.ts
+++ b/packages/api/src/cohort/api.ts
@@ -20,7 +20,7 @@ export const cohortAPI = {
   /** 새 기수 생성 - POST /api/v1/admin/cohorts */
   createCohort: ({ payload }: { payload: PostCreateCohortRequest }) =>
     api.post("/api/v1/admin/cohorts", {
-      body: payload,
+      body: payload as never,
     }) as unknown as Promise<PostCreateCohortResponse>,
 
   /** 기수 전체 목록 - GET /api/v1/admin/cohorts */
@@ -43,7 +43,7 @@ export const cohortAPI = {
   }) =>
     api.patch("/api/v1/admin/cohorts/{id}", {
       params: { path: { id: params.id } },
-      body: payload,
+      body: payload as never,
     }) as unknown as Promise<PatchUpdateCohortResponse>,
 
   /** 기수 삭제 - DELETE /api/v1/admin/cohorts/{id} */
@@ -62,7 +62,7 @@ export const cohortAPI = {
   }) =>
     api.put("/api/v1/admin/cohorts/{id}/parts", {
       params: { path: { id: params.id } },
-      body: payload,
+      body: payload as never,
     }) as unknown as Promise<PutUpdateCohortPartsResponse>,
 };
 

--- a/packages/api/src/cohort/queries.ts
+++ b/packages/api/src/cohort/queries.ts
@@ -6,7 +6,6 @@ import type {
   PatchUpdateCohortParams,
   PatchUpdateCohortRequest,
   DeleteCohortParams,
-  PostCreateCohortRequest,
   PutUpdateCohortPartsParams,
   PutUpdateCohortPartsRequest,
 } from "./types";

--- a/packages/api/src/cohort/types.ts
+++ b/packages/api/src/cohort/types.ts
@@ -24,11 +24,52 @@ export type CreateCohortRequestDtoStatus =
 // UpdateCohortRequestDtoStatus 는 Create 와 동일 값이지만 별도 타입 노출 (기존 호환)
 export type UpdateCohortRequestDtoStatus = CreateCohortRequestDtoStatus;
 
-// ---------- Request DTO 재노출 ----------
-export type CreateCohortRequestDto = components["schemas"]["CreateCohortRequestDto"];
-export type UpdateCohortRequestDto = components["schemas"]["UpdateCohortRequestDto"];
-export type UpdateCohortPartsRequestDto =
-  components["schemas"]["UpdateCohortPartsRequestDto"];
+// ---------- 엔티티 타입 ----------
+//
+// BE 실제 응답은 `{ id, partName, isOpen, applicationSchema }` 형태이나
+// OpenAPI 스키마는 `{ name, isOpen, formSchema: Record<string, never> }` 로
+// 아직 정합되지 않았다 (commit 06b4264 「BE 스키마 필드명 정합화 (partName /
+// applicationSchema)」 이후 BE 측 schema 보강 대기 중).
+// FE 는 BE 실제 응답을 기준으로 타입을 정의하고, generated payload 타입과
+// 충돌하는 부분은 cohort/api.ts 안에서 `as never` cast 로 우회한다.
+//
+export type CohortStatus = CreateCohortRequestDtoStatus;
+export type CohortPartName = CohortPartConfigDtoName;
+export type UpdateCohortStatus = UpdateCohortRequestDtoStatus;
+
+export interface CohortPartConfigDto {
+  id?: number;
+  partName: CohortPartName;
+  isOpen: boolean;
+  applicationSchema: Record<string, unknown>;
+}
+
+/** 기존 호환 alias (FE 내부에서 이 이름으로 참조 중) */
+export type CohortPartConfig = CohortPartConfigDto;
+
+// ---------- Request DTO (process/curriculum/parts 형태를 실제 사용에 맞게 완화) ----------
+export type CreateCohortRequestDto = Omit<
+  components["schemas"]["CreateCohortRequestDto"],
+  "process" | "curriculum" | "applicationForm" | "parts"
+> & {
+  process?: Record<string, unknown>;
+  curriculum?: Record<string, unknown>[];
+  applicationForm?: Record<string, unknown>;
+  parts?: CohortPartConfigDto[];
+};
+
+export type UpdateCohortRequestDto = Omit<
+  components["schemas"]["UpdateCohortRequestDto"],
+  "process" | "curriculum" | "applicationForm"
+> & {
+  process?: Record<string, unknown>;
+  curriculum?: Record<string, unknown>[];
+  applicationForm?: Record<string, unknown>;
+};
+
+export type UpdateCohortPartsRequestDto = {
+  parts: CohortPartConfigDto[];
+};
 
 // ---------- 엔드포인트 시그니처 ----------
 
@@ -60,19 +101,7 @@ export type PutUpdateCohortPartsResponse = CohortDto;
 // GET /api/v1/cohorts/active - 현재 활성 기수 조회 (public)
 export type GetActiveCohortResponse = CohortDto;
 
-// ---------- 엔티티 타입 (BE 응답 schema 미정의 → 수동 정의) ----------
-export type CohortStatus = CreateCohortRequestDtoStatus;
-export type CohortPartName = CohortPartConfigDtoName;
-export type UpdateCohortStatus = UpdateCohortRequestDtoStatus;
-
-export interface CohortPartConfig {
-  id: number;
-  partName: CohortPartName;
-  isOpen: boolean;
-  applicationSchema: Record<string, unknown>;
-}
-export type CohortPartConfigDto = CohortPartConfig;
-
+// ---------- CohortDto 엔티티 (BE 응답 schema 미정의 → 수동 정의) ----------
 export interface CohortDto {
   id: number;
   name: string;
@@ -82,7 +111,7 @@ export interface CohortDto {
   process?: Record<string, unknown>;
   curriculum?: Record<string, unknown>[];
   applicationForm?: Record<string, unknown>;
-  parts?: CohortPartConfig[];
+  parts?: CohortPartConfigDto[];
   createdAt: string;
   updatedAt: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ catalogs:
       specifier: ^3.25.76
       version: 3.25.76
 
+overrides:
+  '@internationalized/date': 3.12.1
+
 importers:
 
   .:
@@ -102,8 +105,8 @@ importers:
         specifier: ^1.1.6
         version: 1.1.6(react@19.2.4)
       '@internationalized/date':
-        specifier: ^3.12.0
-        version: 3.12.0
+        specifier: 3.12.1
+        version: 3.12.1
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.2.2(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(yaml@2.8.3))
@@ -713,89 +716,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -854,9 +873,6 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
-
-  '@internationalized/date@3.12.0':
-    resolution: {integrity: sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==}
 
   '@internationalized/date@3.12.1':
     resolution: {integrity: sha512-6IedsVWXyq4P9Tj+TxuU8WGWM70hYLl12nbYU8jkikVpa6WXapFazPUcHUMDMoWftIDE2ILDkFFte6W2nFCkRQ==}
@@ -919,24 +935,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -1163,66 +1183,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1318,24 +1351,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -1582,41 +1619,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2582,24 +2627,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4043,10 +4092,6 @@ snapshots:
   '@inquirer/type@3.0.10(@types/node@24.12.0)':
     optionalDependencies:
       '@types/node': 24.12.0
-
-  '@internationalized/date@3.12.0':
-    dependencies:
-      '@swc/helpers': 0.5.15
 
   '@internationalized/date@3.12.1':
     dependencies:

--- a/progress.md
+++ b/progress.md
@@ -1,7 +1,7 @@
 # DDD 프론트엔드 진행 현황
 
 > **기준 문서**: 어드민 기능 명세 3.x, SEO 요구사항 4.x, 데이터 모델 5.x, MVP 범위 6.x
-> **코드 스냅샷**: 2026-05-11 (branch: `dev/admin`)
+> **코드 스냅샷**: 2026-05-12 (branch: `dev/admin`)
 > **범례**: ✅ 완료 / 🔧 부분 구현 (UI만 또는 목업 연결) / ⬜ 미구현
 
 ---
@@ -28,7 +28,7 @@
 | 공통 인프라 (admin) | ✅ | 모든 도메인이 openapi-fetch 기반 `api` 싱글톤으로 통일 (commit 241ae4e). storage 보조 queries(`listFiles`·`deleteFile`·`createSignedUrl`·`downloadFile`) 는 후속 |
 | 3.1 기수 관리 | ✅ | 목록/통계/등록/수정/상태변경/파트양식 저장 완료. 부분 실패(`PartsSaveAfterCreateError`) 시 edit 모드 자동 전환 — 브라우저 검증 미실시 |
 | 3.2 사전 알림 | 🔧 | 일괄 발송·CSV·캠페인(PAUSED↔SCHEDULED 전환·편집) ✅, 개별 발송 액션 컬럼 부재 (BE 엔드포인트 없음) |
-| 3.3 지원자 관리 | ✅ | 목록·필터·Drawer 상세·합격불합격 분기 완료. 개인정보 동의 일자 표시. 면접일자 컬럼은 후속 (예약 join 표시) |
+| 3.3 지원자 관리 | ✅ | 목록·필터·Drawer 상세·합격불합격 분기·면접일자 컬럼(슬롯 예약 join) 완료. 개인정보 동의 일자 표시 |
 | 3.3.5 면접 슬롯 | ✅ | `/interview-slots` 신설 — 기수·파트 필터 + CRUD + Drawer + Dialog. `INTERVIEW_SLOTS_NOT_READY` → `InterviewSlotsRequiredModal` 로 페이지 navigate. 예약자 목록·예약 취소는 `ReservationsDrawer` + `CancelReservationDialog` 로 완료 |
 | 3.4 프로젝트 DB | ✅ | 코드 완료 (브라우저 회귀 테스트 미실시) — PDF 업로드는 후속 |
 | 3.5 블로그 DB | ✅ | 코드 완료 (브라우저 회귀 테스트 미실시) |
@@ -160,7 +160,7 @@
 - ✅ 예약자 목록 표시 — 슬롯 행 "예약/정원" 셀 클릭 → `ReservationsDrawer` 오픈 (`InterviewSlotResponseDto.reservations` nested 활용). 지원자명은 `applicationQueries.getAdminApplications({ cohortId })` `useSuspenseQuery` 로 `applicationFormId → applicantName` 매핑
 - ✅ 예약 취소 어드민 UI — `CancelReservationDialog` (AlertDialog) + `useCancelReservationFlow` (`cancelInterviewReservation` mutation → toast + `slotLists()` invalidate). Drawer 안 예약 행 [취소] 버튼에서 confirm 후 호출
 - ⬜ 슬롯 일괄 등록 (날짜 + 시간대 그리드) — 후속 PR
-- ⬜ 지원자 테이블에 면접일자 컬럼 추가 — 슬롯-지원서 join 데이터 활용
+- ✅ 지원자 테이블 면접일자 컬럼 — `useApplicationsBoard` 가 `getInterviewSlots` 응답의 `reservations[].applicationFormId → slot.startAt` 로 Map 빌드해 `ApplicationTable` 에 전달 (commit 197834b)
 
 ---
 
@@ -229,7 +229,7 @@
 | 홈페이지 — 프로젝트 (목록+필터 / 상세 / PDF) | ⬜ | `project/[id]` 라우트만 존재 |
 | 홈페이지 — 블로그 (외부 아티클 링크 목록) | ⬜ | |
 | 어드민 — 기수 관리 (상태 + 수동 변경) | ✅ | 목록/통계/등록/수정/상태변경/파트양식 저장 완료. 부분 실패 시 edit 모드 자동 전환 |
-| 어드민 — 지원자 목록/상세/상태 변경 | ✅ | 목록·Drawer 상세·합격불합격 분기 완료. 개인정보 동의 일자·면접일자 컬럼 미표시 |
+| 어드민 — 지원자 목록/상세/상태 변경 | ✅ | 목록·Drawer 상세·합격불합격 분기·면접일자 컬럼·개인정보 동의 일자 표시 완료 |
 | 어드민 — 사전 알림 DB + 수동 이메일 발송 | 🔧 | 목록/통계/일괄발송/CSV/캠페인(예약 발송 관리) 완료. 개별발송(백엔드 엔드포인트 없음) 대기 중 |
 | 어드민 — 프로젝트 DB 등록/수정 | ✅ | 목록·필터·등록·수정·삭제 코드 완료 (브라우저 검증 미실시) |
 | 어드민 — 블로그 DB 등록/수정 | ✅ | 목록·검색·등록·수정·삭제 코드 완료 (브라우저 검증 미실시) |


### PR DESCRIPTION
## Summary

  어드민 첫 배포(`admin.dddstudy.kr`)를 막던 빌드 실패·경로 불일치·문서 갭을 한 번에 정리한다.

  - **TS 빌드 통과** — `@internationalized/date` 중복 버전 dedupe + `CohortPartConfig` 타입 정합화로 18 개 `tsc
  -b` 에러 제거
  - **VM 배포 경로 결정** — `/opt/ddd-be/frontend` → `/opt/admin/frontend` (BE 부트스트랩 위치와 일치)
  - **FE SSH 셋업 절차 단일 출처화** — `docs/admin-deploy.md` §6 에 키 생성·VM 등록·로컬 검증·Secrets paste 까지
  단계 명문화

  ## 주요 변경

  ### 1. `fix(admin)`: TS 빌드 18 개 에러 제거 (`a051b05`)

  CI Build 단계가 `tsc -b` 에서 18 개 에러로 실패. 두 가지 근본 원인 + 잔여 정합성 7 건.

  - **`@internationalized/date` 두 버전(3.12.0 + 3.12.1) 충돌** — HeroUI v3 `DatePicker` 의 `DateValue` brand
  검사가 `#private` mismatch 로 깨짐. `package.json` 의 `pnpm.overrides` 로 3.12.1 단일화
  - **`CohortPartConfig` 타입과 사용처 어긋남** — BE 실제 응답은 `{ id, partName, isOpen, applicationSchema }`
  인데 OpenAPI generated 는 `{ name, isOpen, formSchema }` (BE 측 schema 보강 대기, commit `06b4264` 이후 상태).
  `packages/api/src/cohort/types.ts` 를 BE 실제 응답 기준으로 재정의하고 `completion.ts` · `serialize.ts` 의
  `.name` · `.formSchema` 접근을 `.partName` · `.applicationSchema` 로 통일. openapi-fetch payload 는 `as never`
  cast 로 우회
  - **잔여 정합성**: unused import 제거 / `erasableSyntaxOnly` parameter property 해체 / `status as string` cast 2
   건 제거 / `Modal.Icon status` prop 제거 / `application.status ?? "-"` null 가드 / interview-slots `id?` 옵셔널
  처리

  ### 2. `chore(deploy)`: 배포 경로 `/opt/ddd-be/frontend` → `/opt/admin/frontend` (`a182be1`)

  BE 가 frontend 정적 디렉터리를 `/opt/admin/frontend` 로 부트스트랩하기로 결정 (BE 영역과 격리). 워크플로의 SCP
  target / atomic swap `cd` 경로 + `docs/admin-deploy.md` §1·§3·§7·§9·§12 의 경로 표기 일괄 동기화. 워크플로 quote
   스타일도 single → double 통일.

  ### 3. `docs(deploy)`: FE SSH 셋업 절차 보강 (`4837dfa`)

  `docs/admin-deploy.md` §6 를 단순 secret 이름 나열에서 셋업 플레이북으로 확장.

  - §6.1 `ssh-keygen -t ed25519 -f ~/.ssh/ddd_fe_deploy -N ""` 키 쌍 생성 + 플래그별 의미
  - §6.2 `.pub` 등록 3 경로 — (A) 팀 Google 계정으로 GCP 콘솔 브라우저 SSH (권장), (B) BE 의뢰, (C) 메타데이터 UI
  (comment 함정 주의)
  - §6.3 `ssh -i ddd_fe_deploy -o IdentitiesOnly=yes` 로컬 검증 + VM 안 BE 부트스트랩 점검
  - §6.4 GitHub Secrets paste

  §7 첫 배포 순서 6 단계 재구성 + §12 FE 체크리스트 7 항목으로 분해.
  `id?` 옵셔널 처리

  ### 2. `chore(deploy)`: 배포 경로 `/opt/ddd-be/frontend` → `/opt/admin/frontend` (`a182be1`)

  BE 가 frontend 정적 디렉터리를 `/opt/admin/frontend` 로 부트스트랩하기로 결정 (BE 영역과 격리). 워크플로의     SCP target / atomic swap `cd` 경로 + `docs/admin-deploy.md` §1·§3·§7·§9·§12 의 경로 표기 일괄 동기화.
  워크플로 quote 스타일도 single → double 통일.

  ### 3. `docs(deploy)`: FE SSH 셋업 절차 보강 (`4837dfa`)

  `docs/admin-deploy.md` §6 를 단순 secret 이름 나열에서 셋업 플레이북으로 확장.
  - §6.1 `ssh-keygen -t ed25519 -f ~/.ssh/ddd_fe_deploy -N ""` 키 쌍 생성 + 플래그별 의미
  - §6.2 `.pub` 등록 3 경로 — (A) 팀 Google 계정으로 GCP 콘솔 브라우저 SSH (권장), (B) BE 의뢰, (C) 메타데이터 UI
  (comment 함정 주의)
  - §6.3 `ssh -i ddd_fe_deploy -o IdentitiesOnly=yes` 로컬 검증 + VM 안 BE 부트스트랩 점검
  - §6.4 GitHub Secrets paste
  §7 첫 배포 순서 6 단계 재구성 + §12 FE 체크리스트 7 항목으로 분해.

  ### 4. `docs(progress)`: 면접일자 컬럼 반영 (`3080479`)

  `docs/admin-implementation-status.md` 와 `progress.md` 의 stale 항목 정리. 지원자 테이블 면접일자 컬럼이
  `useApplicationsBoard` 의 slot 예약 join 으로 완료된 상태 반영 (commit `197834b` 후속 문서 동기화). `#7` 미구현
  항목은 "슬롯 중복 안내"(`apps/web` 영역) 로 좁힘.

  ## Test plan

  - [x] 로컬 `pnpm --filter @ddd/admin build` 통과 (tsc -b ✓ / vite build ✓)                                        - [x] `node_modules/.pnpm/@internationalized+date@*` 단일 버전(3.12.1) 확인
  - [x] `ssh -i ~/.ssh/ddd_fe_deploy -o IdentitiesOnly=yes dddstudy1@<HOST>` 로컬 인증 통과
  - [x] VM 안에서 `/opt/admin/frontend/` 쓰기 권한 OK + `current → releases/placeholder` 심볼릭 정상
  - [ ] GitHub Secrets 3 종 (`GCP_VM_HOST` / `GCP_VM_USER` / `GCP_VM_SSH_KEY`) 등록 확인
  - [ ] Actions 탭 → "Deploy admin to GCP VM" → Run workflow → 단계별 통과 (Install / Build / Pack / SCP / Atomic
  swap / Health check)
  - [ ] `admin-deploy.md §8` 브라우저 검증 시나리오 1~8 통과                                                          - [ ] `/` 로그인 페이지 노출
    - [ ] Google OAuth → `/applications` 리다이렉트
    - [ ] 쿠키 `access_token` / `refresh_token` HttpOnly + Secure + SameSite=Lax
    - [ ] 보호 API 호출 시 Cookie 자동 첨부                                                                           - [ ] `/applications` 직접 URL 새로고침 시 SPA fallback 동작

  ## 후속 작업 (별도 PR)

  - BE OpenAPI schema 의 `CohortPartConfigDto` 를 실제 응답(`partName` / `applicationSchema` / `id`) 에 맞춰 보강
  → FE 의 `as never` cast 제거 가능                                                                                 - `@ddd/api` 의 storage 보조 queries (`listFiles` / `deleteFile` / `createSignedUrl` / `downloadFile`) 추가
  - `apps/web` 배포 워크플로 추가